### PR TITLE
chore(aptos): Update to aptos-node-v1.9.3

### DIFF
--- a/aptos/VERSION
+++ b/aptos/VERSION
@@ -1,1 +1,1 @@
-aptos-node-v1.9.2
+aptos-node-v1.9.3


### PR DESCRIPTION
Automated update for `aptos`

Old version: `aptos-node-v1.9.2`
New version: `aptos-node-v1.9.3`