### PR TITLE
chore(near): Update to statelessnet-81.1

### DIFF
--- a/near/VERSION
+++ b/near/VERSION
@@ -1,1 +1,1 @@
-1.36.5
+statelessnet-81.1


### PR DESCRIPTION
Automated update for `near`

Old version: `1.36.5`
New version: `statelessnet-81.1`