### PR TITLE
chore(near): Update to 1.36.5

### DIFF
--- a/near/VERSION
+++ b/near/VERSION
@@ -1,1 +1,1 @@
-statelessnet-81.1
+1.36.5


### PR DESCRIPTION
Automated update for `near`

Old version: `statelessnet-81.1`
New version: `1.36.5`