### PR TITLE
chore(aptos): Update to aptos-indexer-grpc-v1.4.0

### DIFF
--- a/aptos/VERSION
+++ b/aptos/VERSION
@@ -1,1 +1,1 @@
-aptos-node-v1.9.3
+aptos-indexer-grpc-v1.4.0


### PR DESCRIPTION
Automated update for `aptos`

Old version: `aptos-node-v1.9.3`
New version: `aptos-indexer-grpc-v1.4.0`