### PR TITLE
chore(aptos): Update to aptos-cli-v3.3.0

### DIFF
--- a/aptos/VERSION
+++ b/aptos/VERSION
@@ -1,1 +1,1 @@
-aptos-node-v1.9.3
+aptos-cli-v3.3.0


### PR DESCRIPTION
Automated update for `aptos`

Old version: `aptos-node-v1.9.3`
New version: `aptos-cli-v3.3.0`