### PR TITLE
chore(sui): Update to testnet-v1.26.0

### DIFF
--- a/sui/VERSION
+++ b/sui/VERSION
@@ -1,1 +1,1 @@
-mainnet-v1.25.1
+testnet-v1.26.0


### PR DESCRIPTION
Automated update for `sui`

Old version: `mainnet-v1.25.1`
New version: `testnet-v1.26.0`