### PR TITLE
chore(sui): Update to mainnet-v1.25.3

### DIFF
--- a/sui/VERSION
+++ b/sui/VERSION
@@ -1,1 +1,1 @@
-testnet-v1.26.0
+mainnet-v1.25.3


### PR DESCRIPTION
Automated update for `sui`

Old version: `testnet-v1.26.0`
New version: `mainnet-v1.25.3`