### PR TITLE
chore(sui): Update to mainnet-v1.26.1

### DIFF
--- a/sui/VERSION
+++ b/sui/VERSION
@@ -1,1 +1,1 @@
-testnet-v1.26.1
+mainnet-v1.26.1


### PR DESCRIPTION
Automated update for `sui`

Old version: `testnet-v1.26.1`
New version: `mainnet-v1.26.1`