### PR TITLE
chore(sui): Update to mainnet-v1.27.4

### DIFF
--- a/sui/VERSION
+++ b/sui/VERSION
@@ -1,1 +1,1 @@
-testnet-v1.28.2
+mainnet-v1.27.4


### PR DESCRIPTION
Automated update for `sui`

Old version: `testnet-v1.28.2`
New version: `mainnet-v1.27.4`