### PR TITLE
chore(sui): Update to testnet-v1.28.3

### DIFF
--- a/sui/VERSION
+++ b/sui/VERSION
@@ -1,1 +1,1 @@
-mainnet-v1.27.4
+testnet-v1.28.3


### PR DESCRIPTION
Automated update for `sui`

Old version: `mainnet-v1.27.4`
New version: `testnet-v1.28.3`