### PR TITLE
chore(agoric): Update to agoric-upgrade-16

### DIFF
--- a/agoric/VERSION
+++ b/agoric/VERSION
@@ -1,1 +1,1 @@
-agoric-upgrade-13
+agoric-upgrade-16


### PR DESCRIPTION
Automated update for `agoric`

Old version: `agoric-upgrade-13`
New version: `agoric-upgrade-16`