### PR TITLE
chore(sui): Update to testnet-v1.29.0

### DIFF
--- a/sui/VERSION
+++ b/sui/VERSION
@@ -1,1 +1,1 @@
-testnet-v1.28.3
+testnet-v1.29.0


### PR DESCRIPTION
Automated update for `sui`

Old version: `testnet-v1.28.3`
New version: `testnet-v1.29.0`