### PR TITLE
chore(sui): Update to mainnet-v1.28.3

### DIFF
--- a/sui/VERSION
+++ b/sui/VERSION
@@ -1,1 +1,1 @@
-testnet-v1.29.0
+mainnet-v1.28.3


### PR DESCRIPTION
Automated update for `sui`

Old version: `testnet-v1.29.0`
New version: `mainnet-v1.28.3`