### PR TITLE
chore(sui): Update to testnet-v1.29.2

### DIFF
--- a/sui/VERSION
+++ b/sui/VERSION
@@ -1,1 +1,1 @@
-mainnet-v1.28.3
+testnet-v1.29.2


### PR DESCRIPTION
Automated update for `sui`

Old version: `mainnet-v1.28.3`
New version: `testnet-v1.29.2`