### PR TITLE
chore(aptos): Update to aptos-node-v1.17.2

### DIFF
--- a/aptos/VERSION
+++ b/aptos/VERSION
@@ -1,1 +1,1 @@
-aptos-node-v1.9.3
+aptos-node-v1.17.2


### PR DESCRIPTION
Automated update for `aptos`

Old version: `aptos-node-v1.9.3`
New version: `aptos-node-v1.17.2`