### PR TITLE
chore(sui): Update to testnet-v1.36.0

### DIFF
--- a/sui/VERSION
+++ b/sui/VERSION
@@ -1,1 +1,1 @@
-mainnet-v1.35.2
+testnet-v1.36.0


### PR DESCRIPTION
Automated update for `sui`

Old version: `mainnet-v1.35.2`
New version: `testnet-v1.36.0`