### PR TITLE
chore(sui): Update to testnet-v1.36.1

### DIFF
--- a/sui/VERSION
+++ b/sui/VERSION
@@ -1,1 +1,1 @@
-testnet-v1.36.0
+testnet-v1.36.1


### PR DESCRIPTION
Automated update for `sui`

Old version: `testnet-v1.36.0`
New version: `testnet-v1.36.1`