### PR TITLE
chore(sui): Update to testnet-v1.36.2

### DIFF
--- a/sui/VERSION
+++ b/sui/VERSION
@@ -1,1 +1,1 @@
-mainnet-v1.35.4
+testnet-v1.36.2


### PR DESCRIPTION
Automated update for `sui`

Old version: `mainnet-v1.35.4`
New version: `testnet-v1.36.2`