### PR TITLE
chore(sui): Update to mainnet-v1.39.3

### DIFF
--- a/sui/VERSION
+++ b/sui/VERSION
@@ -1,1 +1,1 @@
-testnet-v1.39.2
+mainnet-v1.39.3


### PR DESCRIPTION
Automated update for `sui`

Old version: `testnet-v1.39.2`
New version: `mainnet-v1.39.3`