### PR TITLE
chore(sui): Update to mainnet-v1.39.4

### DIFF
--- a/sui/VERSION
+++ b/sui/VERSION
@@ -1,1 +1,1 @@
-mainnet-v1.39.3
+mainnet-v1.39.4


### PR DESCRIPTION
Automated update for `sui`

Old version: `mainnet-v1.39.3`
New version: `mainnet-v1.39.4`